### PR TITLE
chore: modernize addon templates for HA 2025

### DIFF
--- a/.README.j2
+++ b/.README.j2
@@ -40,11 +40,8 @@ Use the following URL to add this repository:
 ### &#10003; [{{ addon.name }}][addon-{{ addon.target }}]
 
 ![Latest Version][{{ addon.target }}-version-shield]
-![Supports armhf Architecture][{{ addon.target }}-armhf-shield]
-![Supports armv7 Architecture][{{ addon.target }}-armv7-shield]
 ![Supports aarch64 Architecture][{{ addon.target }}-aarch64-shield]
 ![Supports amd64 Architecture][{{ addon.target }}-amd64-shield]
-![Supports i386 Architecture][{{ addon.target }}-i386-shield]
 
 {{ addon.description }}
 
@@ -76,7 +73,7 @@ in this channel.
 [addon-doc-{{ addon.target}}]: {{ addon.repo }}/blob/{{ addon.version }}/README.md
 [{{ addon.target }}-issue]: {{ addon.repo }}/issues
 [{{ addon.target }}-version-shield]: https://img.shields.io/badge/version-{{ addon.version }}-blue.svg
-{% for arch in ['aarch64', 'amd64', 'armhf', 'armv7', 'i386'] %}
+{% for arch in ['aarch64', 'amd64'] %}
 {% if arch in addon.archs %}
 [{{ addon.target }}-{{ arch }}-shield]: https://img.shields.io/badge/{{ arch }}-yes-green.svg
 {% else %}
@@ -87,6 +84,6 @@ in this channel.
 
 [issue]: https://github.com/{{ name }}/issues
 [license-shield]: https://img.shields.io/github/license/{{ name }}.svg
-[maintenance-shield]: https://img.shields.io/maintenance/yes/2023.svg
+[maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg
 [project-stage-shield]: https://img.shields.io/badge/project%20stage-development-yellowgreen.svg
 [semver]: http://semver.org/spec/v2.0.0.html

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,0 @@
-{
-  "name": "JetHome Add-ons: BETA",
-  "url": "https://github.com/jethome-hassio-addons/repository-beta",
-  "maintainer": "Pavel Sokolov <pavel@jethome.ru>"
-}

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,4 @@
+---
+name: "JetHome Add-ons: BETA"
+url: https://github.com/jethome-hassio-addons/repository-beta
+maintainer: JetHome Team <dev@jethome.com>


### PR DESCRIPTION
## Summary

- Migrate repository.json to repository.yaml format (HA 2025 standard)
- Update maintainer to JetHome Team <dev@jethome.com>
- Remove deprecated architecture badges (armv7, armhf, i386) from README template
- Update maintenance year to 2026

## Breaking Changes

README template no longer shows badges for 32-bit architectures (i386, armhf, armv7) which were deprecated by Home Assistant in December 2025.

## Test plan

- [ ] Verify repository is recognized by Home Assistant after merge
- [ ] Verify README renders correctly with new architecture badges