### PR TITLE
fix: add devicetree permission for device detection

### DIFF
--- a/jethub-mqtt-io/config.yaml
+++ b/jethub-mqtt-io/config.yaml
@@ -1,5 +1,5 @@
 name: JetHome JetHub mqtt-io peripheral exposer
-version: 0.3.0
+version: beta  # sha256:12fdde3def64b6676335f700ae9072575fd5f2546349b697ff63f31b2cd535c3
 slug: jethub-mqtt-io
 description: Expose JetHome JetHub peripheral (relays, inputs, etc..) via mqtt-io
 url: https://github.com/jethome-hassio-addons/addon-jethub-mqtt-io
@@ -10,6 +10,7 @@ arch:
 - aarch64
 homeassistant: 2021.8.8
 gpio: true
+devicetree: true
 apparmor: false
 options:
   log_level: info
@@ -27,4 +28,4 @@ schema:
     password: str?
     client_id: str
     topic_prefix: str
-image: ghcr.io/jethome-hassio-addons/jethub-mqtt-io/{arch}
+image: ghcr.io/jethome-iot/addon-jethub-gpio2mqtt


### PR DESCRIPTION
## Problem

Addon cannot access `/proc/device-tree` for device model detection:
```
[detect-model] /proc/device-tree/model not found or unknown
[detect-model] /proc/device-tree/compatible not found or unknown
```

## Solution

Add `devicetree: true` to config.yaml - provides read access to `/sys/firmware/devicetree/base` (symlinked as `/proc/device-tree`).

## Test plan

- [ ] Verify addon can detect device model